### PR TITLE
Add Text primitive type class

### DIFF
--- a/src/Column.ts
+++ b/src/Column.ts
@@ -3,6 +3,7 @@ import { EntityTypeAnnotation } from './Entity';
 
 declare interface ColumnAnnotation {
     name?: string;
+    description?: string;
     nullable?: boolean;
     unique?: boolean;
     length?: number;

--- a/src/Entity.ts
+++ b/src/Entity.ts
@@ -16,7 +16,7 @@ function Entity(annotation?: EntityAnnotation) {
     return (target: any) => {
         const entityType = target as EntityTypeAnnotation;
         let embeddable = false;
-        if (entityType.Entity) {
+        if (entityType.Entity && entityType.Entity.name === target.name) {
             embeddable = (entityType.Entity as { embeddable: boolean }).embeddable;
         }
         entityType.Entity = Object.assign({
@@ -28,6 +28,9 @@ function Entity(annotation?: EntityAnnotation) {
                 embeddable
             });
         }
+        // set extra decorator for @themost/data#EdmMapping
+        target.entityTypeDecorator = entityType.Entity.name;
+        // set privileges
         Permission(annotation && annotation.privileges);
     };
 }

--- a/src/EntityLoaderStrategy.ts
+++ b/src/EntityLoaderStrategy.ts
@@ -321,6 +321,10 @@ class EntityLoaderStrategy extends SchemaLoaderStrategy {
                         readonly: Object.prototype.hasOwnProperty.call(column, 'insertable') ? !column.insertable : false,
                         editable: Object.prototype.hasOwnProperty.call(column, 'updatable') ? column.updatable : true
                     }
+                    // set description
+                    if (column.length) {
+                        field.description = column.description;
+                    }
                     // set size
                     if (column.length) {
                         field.size = column.length;

--- a/src/ManyToMany.ts
+++ b/src/ManyToMany.ts
@@ -53,15 +53,16 @@ function ManyToMany(annotation?: ManyToManyAnnotation) {
                 targetEntity = r.name;
             }
         }
-        if (targetEntity == null) {
-            throw new EntityNotFoundException();
-        }
         Permission(annotation.privileges);
         // set value property
         Object.assign(column, {
-            manyToMany: value,
-            type: targetEntity
+            manyToMany: value
         } as ManyToManyColumnAnnotation);
+        if (targetEntity) {
+            Object.assign(column, {
+                type: targetEntity
+            });
+        }
         // finally, set column annotation
         columns.Column.set(propertyKey, column);
       };

--- a/src/types/Text.ts
+++ b/src/types/Text.ts
@@ -1,0 +1,5 @@
+export class Text extends String {
+    constructor(value?: any) {
+        super(value);
+    }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './Duration';
 export * from './Counter';
 export * from './Language';
+export * from './Text';


### PR DESCRIPTION
This PR adds `Text` which extends `String` to be used while defining `Column.type`

```
class Thing {
    @Column({
        type: Text,
        nullable: false
    })
    name;
}
```